### PR TITLE
Add claude-code cask

### DIFF
--- a/packages/nix/modules/darwin/homebrew.nix
+++ b/packages/nix/modules/darwin/homebrew.nix
@@ -128,6 +128,7 @@
     "raycast"
     "chatgpt"
     "claude"
+    "claude-code" # Claude Code IDE
     "jordanbaird-ice"
 
     # Media and Entertainment

--- a/packages/node-tools/package.json
+++ b/packages/node-tools/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@typescript/native-preview": "latest",
-    "@anthropic-ai/claude-code": "latest"
+    "@typescript/native-preview": "latest"
   },
   "scripts": {
     "global-install": "./install.sh"


### PR DESCRIPTION
## Summary
- remove `@anthropic-ai/claude-code` from global npm packages
- install `claude-code` via Homebrew.nix

## Testing
- `bun install`

------
https://chatgpt.com/codex/tasks/task_e_687c8ae03d7883248f95acdcfe844642